### PR TITLE
fix: Use the node file version in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -43,7 +43,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+          node-version-file: .nvmrc
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This pull request solves a problem that prevented the merge of any other pull requests on the repository. Indeed, the testing workflow used the latest available node version, while a file containing the version to be used was available.

The problem was noticed because the dependencies no longer installed correctly with this version.