### PR TITLE
tech: Remove the job to check dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,6 @@ on:
   merge_group:
 
 jobs:
-  dependencies-check:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check expo dependencies
-        run: npm run dependencies-check
 
   lint:
     if: github.event.pull_request.draft == false

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "lint:fix": "expo lint --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "version": "node scripts/update-version.js && git add .",
-    "dependencies-check": "npx expo-doctor",
-    "dependencies-update": "expo install --check"
+    "version": "node scripts/update-version.js && git add ."
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
## Problem

The dependency check is not a good job because it blocks the ci and adjustments are longer to apply.

## Solution
Remove the job.