### PR TITLE
feat: record journeys, show the profile and the confirmed journeys

### DIFF
--- a/App.js
+++ b/App.js
@@ -19,9 +19,11 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import ApiUnavailable from "./components/ApiUnavailable";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
+import RecordJourneyScreen from "./screens/RecordJourneyScreen";
 import RegistrationScreen from "./screens/RegistrationScreen";
 import { colors } from "./theme/tokens";
 import { checkHealth } from "./utils/api-fetch";
+import { getSession } from "./utils/session";
 
 const Stack = createNativeStackNavigator();
 
@@ -51,19 +53,27 @@ export default function App() {
     DMSans_700Bold,
   });
 
-  // Gate the app on the API health: the auth screens are only shown when the
-  // backend answers. Otherwise an error message is displayed.
+  // The app is gated on the API health: screens are only shown when the backend
+  // answers. The stored session then decides the entry screen, so a logged-in
+  // user skips the auth flow.
   const [apiStatus, setApiStatus] = useState("loading"); // "loading" | "ready" | "error"
+  const [initialRoute, setInitialRoute] = useState("Register");
 
-  const refreshApiStatus = useCallback(async () => {
+  const start = useCallback(async () => {
     setApiStatus("loading");
     const healthy = await checkHealth();
-    setApiStatus(healthy ? "ready" : "error");
+    if (!healthy) {
+      setApiStatus("error");
+      return;
+    }
+    const session = await getSession();
+    setInitialRoute(session ? "Home" : "Register");
+    setApiStatus("ready");
   }, []);
 
   useEffect(() => {
-    refreshApiStatus();
-  }, [refreshApiStatus]);
+    start();
+  }, [start]);
 
   if (apiStatus === "loading") {
     return (
@@ -74,19 +84,20 @@ export default function App() {
   }
 
   if (apiStatus === "error") {
-    return <ApiUnavailable onRetry={refreshApiStatus} />;
+    return <ApiUnavailable onRetry={start} />;
   }
 
   return (
     <SafeAreaProvider>
       <NavigationContainer theme={navTheme}>
         <Stack.Navigator
-          initialRouteName="Register"
+          initialRouteName={initialRoute}
           screenOptions={{ headerShown: false, contentStyle: { backgroundColor: colors.bg } }}
         >
           <Stack.Screen name="Register" component={RegistrationScreen} />
           <Stack.Screen name="Login" component={LoginScreen} />
           <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="RecordJourney" component={RecordJourneyScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/App.js
+++ b/App.js
@@ -18,7 +18,10 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import ApiUnavailable from "./components/ApiUnavailable";
 import HomeScreen from "./screens/HomeScreen";
+import JourneyDetailScreen from "./screens/JourneyDetailScreen";
+import JourneysScreen from "./screens/JourneysScreen";
 import LoginScreen from "./screens/LoginScreen";
+import ProfileScreen from "./screens/ProfileScreen";
 import RecordJourneyScreen from "./screens/RecordJourneyScreen";
 import RegistrationScreen from "./screens/RegistrationScreen";
 import { colors } from "./theme/tokens";
@@ -98,6 +101,9 @@ export default function App() {
           <Stack.Screen name="Login" component={LoginScreen} />
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="RecordJourney" component={RecordJourneyScreen} />
+          <Stack.Screen name="Journeys" component={JourneysScreen} />
+          <Stack.Screen name="JourneyDetail" component={JourneyDetailScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-font"
+      "expo-font",
+      "expo-secure-store"
     ]
   }
 }

--- a/components/AddressAutocomplete.js
+++ b/components/AddressAutocomplete.js
@@ -1,0 +1,149 @@
+import { Feather } from "@expo/vector-icons";
+import React, { useEffect, useRef, useState } from "react";
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+import { colors, fonts, radius } from "../theme/tokens";
+import { searchAddresses } from "../utils/location";
+import BrandInput from "./BrandInput";
+
+const DEBOUNCE_MS = 350;
+
+/**
+ * Address field with debounced autocomplete suggestions (OpenStreetMap).
+ * Selecting a suggestion gives back its label and coordinates, so the caller
+ * doesn't need to geocode again.
+ *
+ * @param {object}   props
+ * @param {string}   props.label
+ * @param {string}   props.icon              - Feather icon name
+ * @param {string}   props.placeholder
+ * @param {string}   props.value
+ * @param {Function} props.onChangeText      - called on every keystroke
+ * @param {Function} props.onSelect          - called with { label, latitude, longitude }
+ * @param {string}   [props.testID]
+ */
+export default function AddressAutocomplete({
+  label,
+  icon,
+  placeholder,
+  value,
+  onChangeText,
+  onSelect,
+  testID,
+}) {
+  const [suggestions, setSuggestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const timer = useRef(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, []);
+
+  const handleChange = (text) => {
+    onChangeText(text);
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
+    if (text.trim().length < 3) {
+      setSuggestions([]);
+      return;
+    }
+    timer.current = setTimeout(async () => {
+      setLoading(true);
+      const results = await searchAddresses(text);
+      if (mounted.current) {
+        setSuggestions(results);
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+  };
+
+  const handleSelect = (suggestion) => {
+    setSuggestions([]);
+    onSelect(suggestion);
+  };
+
+  return (
+    <View style={styles.field}>
+      <BrandInput
+        label={label}
+        icon={icon}
+        placeholder={placeholder}
+        value={value}
+        onChangeText={handleChange}
+        autoCorrect={false}
+        testID={testID}
+        accessibilityLabel={label}
+      />
+
+      {loading && (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator size="small" color={colors.tealDark} />
+        </View>
+      )}
+
+      {suggestions.length > 0 && (
+        <View style={styles.suggestions}>
+          {suggestions.map((suggestion, index) => (
+            <TouchableOpacity
+              key={`${suggestion.label}-${index}`}
+              style={[styles.suggestion, index > 0 && styles.suggestionDivider]}
+              onPress={() => handleSelect(suggestion)}
+              accessibilityRole="button"
+              accessibilityLabel={suggestion.label}
+              testID={`${testID}-suggestion-${index}`}
+            >
+              <Feather name="map-pin" size={14} color={colors.textLight} style={styles.suggestionIcon} />
+              <Text style={styles.suggestionText} numberOfLines={2}>{suggestion.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  field: {
+    marginBottom: 16,
+  },
+  loadingRow: {
+    paddingVertical: 8,
+    alignItems: "flex-start",
+    marginLeft: 4,
+  },
+  suggestions: {
+    marginTop: 6,
+    backgroundColor: colors.surface,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    overflow: "hidden",
+  },
+  suggestion: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  suggestionDivider: {
+    borderTopWidth: 1,
+    borderTopColor: colors.beige,
+  },
+  suggestionIcon: {
+    marginTop: 1,
+  },
+  suggestionText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.navy,
+  },
+});

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,11 @@
+// Shared display labels, kept in sync with the web app's src/constants.js.
+
+export const USER_ROLES = {
+  valid: "Accompagnateur",
+  invalid: "Personne handicapé",
+};
+
+export const USER_GENRE = {
+  F: "Mme",
+  M: "Monsieur",
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -21,6 +21,24 @@ jest.mock("@expo/vector-icons", () => {
   );
 });
 
+// expo-secure-store → in-memory store (no native keychain).
+jest.mock("expo-secure-store", () => {
+  const store = new Map();
+  return {
+    setItemAsync: jest.fn(async (key, value) => { store.set(key, value); }),
+    getItemAsync: jest.fn(async (key) => (store.has(key) ? store.get(key) : null)),
+    deleteItemAsync: jest.fn(async (key) => { store.delete(key); }),
+  };
+});
+
+// expo-location → no-op defaults (individual tests override the return values).
+jest.mock("expo-location", () => ({
+  requestForegroundPermissionsAsync: jest.fn(async () => ({ status: "granted" })),
+  getCurrentPositionAsync: jest.fn(async () => ({ coords: { latitude: 0, longitude: 0 } })),
+  reverseGeocodeAsync: jest.fn(async () => []),
+  geocodeAsync: jest.fn(async () => []),
+}));
+
 // expo-font → behave as if fonts are already loaded.
 jest.mock("expo-font", () => ({
   useFonts: () => [true, null],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "expo": "~54.0.0",
         "expo-env": "^1.1.1",
         "expo-font": "~14.0.12",
+        "expo-location": "~19.0.8",
+        "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -6486,6 +6488,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-location": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.26",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
@@ -6513,6 +6524,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "expo": "~54.0.0",
     "expo-env": "^1.1.1",
     "expo-font": "~14.0.12",
+    "expo-location": "~19.0.8",
+    "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,6 +14,7 @@ import {
 import logo from "../assets/kompagnon-logo.png";
 import { colors, fonts, radius, shadow } from "../theme/tokens";
 import { checkHealth } from "../utils/api-fetch";
+import { clearSession } from "../utils/session";
 
 export default function HomeScreen() {
   const navigation = useNavigation();
@@ -31,7 +32,8 @@ export default function HomeScreen() {
     return () => { mounted = false; };
   }, []);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await clearSession();
     navigation.reset({ index: 0, routes: [{ name: "Login" }] });
   };
 
@@ -57,6 +59,16 @@ export default function HomeScreen() {
             {apiIsActive ? "API connectée" : "API injoignable"}
           </Text>
         </View>
+
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={() => navigation.navigate("RecordJourney")}
+          accessibilityRole="button"
+          accessibilityLabel="Demander un accompagnement"
+        >
+          <Feather name="navigation" size={18} color={colors.textOnDark} />
+          <Text style={styles.primaryButtonText}>Demander un accompagnement</Text>
+        </TouchableOpacity>
 
         <TouchableOpacity
           style={styles.logoutButton}
@@ -122,6 +134,24 @@ const styles = StyleSheet.create({
   statusText: {
     fontSize: 13,
     fontFamily: fonts.bodySemiBold,
+  },
+  primaryButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    alignSelf: "stretch",
+    paddingVertical: 18,
+    borderRadius: radius.full,
+    backgroundColor: colors.teal,
+    marginBottom: 16,
+    ...shadow.teal,
+  },
+  primaryButtonText: {
+    color: colors.textOnDark,
+    fontSize: 16,
+    fontFamily: fonts.bodyBold,
+    letterSpacing: 0.3,
   },
   logoutButton: {
     paddingVertical: 14,

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -14,7 +14,6 @@ import {
 import logo from "../assets/kompagnon-logo.png";
 import { colors, fonts, radius, shadow } from "../theme/tokens";
 import { checkHealth } from "../utils/api-fetch";
-import { clearSession } from "../utils/session";
 
 export default function HomeScreen() {
   const navigation = useNavigation();
@@ -32,18 +31,13 @@ export default function HomeScreen() {
     return () => { mounted = false; };
   }, []);
 
-  const handleLogout = async () => {
-    await clearSession();
-    navigation.reset({ index: 0, routes: [{ name: "Login" }] });
-  };
-
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <View style={styles.container}>
         <Image source={logo} style={styles.logo} resizeMode="cover" accessibilityRole="image" accessibilityLabel="Logo Kompagnon" />
         <Text style={styles.title}>Bienvenue sur Kompagnon</Text>
-        <Text style={styles.subtitle}>L'accompagnement accessible, pensé pour tous.</Text>
+        <Text style={styles.subtitle}>L&apos;accompagnement accessible, pensé pour tous.</Text>
 
         <View
           style={[styles.statusPill, apiIsActive ? styles.statusOk : styles.statusDown]}
@@ -70,14 +64,27 @@ export default function HomeScreen() {
           <Text style={styles.primaryButtonText}>Demander un accompagnement</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.logoutButton}
-          onPress={handleLogout}
-          accessibilityRole="button"
-          accessibilityLabel="Se déconnecter"
-        >
-          <Text style={styles.logoutText}>Se déconnecter</Text>
-        </TouchableOpacity>
+        <View style={styles.secondaryRow}>
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={() => navigation.navigate("Journeys")}
+            accessibilityRole="button"
+            accessibilityLabel="Mes trajets"
+          >
+            <Feather name="calendar" size={17} color={colors.navy} />
+            <Text style={styles.secondaryButtonText}>Mes trajets</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={() => navigation.navigate("Profile")}
+            accessibilityRole="button"
+            accessibilityLabel="Mon profil"
+          >
+            <Feather name="user" size={17} color={colors.navy} />
+            <Text style={styles.secondaryButtonText}>Mon profil</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -153,17 +160,26 @@ const styles = StyleSheet.create({
     fontFamily: fonts.bodyBold,
     letterSpacing: 0.3,
   },
-  logoutButton: {
+  secondaryRow: {
+    flexDirection: "row",
+    alignSelf: "stretch",
+    gap: 12,
+  },
+  secondaryButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
     paddingVertical: 14,
-    paddingHorizontal: 28,
     borderRadius: radius.full,
     borderWidth: 1.5,
     borderColor: colors.border,
     backgroundColor: colors.surface,
   },
-  logoutText: {
+  secondaryButtonText: {
     color: colors.navy,
-    fontSize: 15,
+    fontSize: 14,
     fontFamily: fonts.bodyBold,
   },
 });

--- a/screens/JourneyDetailScreen.js
+++ b/screens/JourneyDetailScreen.js
@@ -1,0 +1,407 @@
+import { Feather } from "@expo/vector-icons";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { StatusBar } from "expo-status-bar";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import { colors, fonts, radius, shadow } from "../theme/tokens";
+import { formatShortDate, formatTime } from "../utils/format";
+import { getJourney, getJourneyMatches, isConfirmedMatch } from "../utils/journeys";
+import { getSession } from "../utils/session";
+
+export default function JourneyDetailScreen() {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const { journeyId } = route.params ?? {};
+
+  const [journey, setJourney] = useState(null);
+  const [match, setMatch] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const session = await getSession();
+    if (!session) {
+      setError("Votre session a expiré. Reconnectez-vous.");
+      setLoading(false);
+      return;
+    }
+
+    const [journeyResult, matchesResult] = await Promise.all([
+      getJourney({ token: session.token, journeyId }),
+      getJourneyMatches({ token: session.token, journeyId }),
+    ]);
+
+    if (!journeyResult.success) {
+      setError(journeyResult.message);
+      setLoading(false);
+      return;
+    }
+
+    setJourney(journeyResult.journey);
+    setMatch((matchesResult.matches ?? []).find(isConfirmedMatch) ?? null);
+    setLoading(false);
+  }, [journeyId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <Feather name="arrow-left" size={22} color={colors.navy} />
+          </TouchableOpacity>
+          <Text style={styles.title}>Détail du trajet</Text>
+        </View>
+
+        {loading && (
+          <View style={styles.centered} testID="journey-detail-loading">
+            <ActivityIndicator color={colors.teal} accessibilityLabel="Chargement…" />
+          </View>
+        )}
+
+        {!loading && error && (
+          <View
+            style={styles.errorContainer}
+            testID="journey-detail-error"
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
+          >
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity
+              style={styles.retryButton}
+              onPress={load}
+              accessibilityRole="button"
+              accessibilityLabel="Réessayer"
+            >
+              <Text style={styles.retryText}>Réessayer</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {!loading && !error && journey && (
+          <>
+            <View style={styles.card}>
+              <Text style={styles.date}>{formatShortDate(journey.departureTime)}</Text>
+
+              <View style={styles.step}>
+                <View style={styles.stepIcon}>
+                  <Feather name="map-pin" size={15} color={colors.tealDark} />
+                </View>
+                <View style={styles.stepBody}>
+                  <Text style={styles.stepLabel}>Départ</Text>
+                  <Text style={styles.stepValue}>{journey.departureAddress}</Text>
+                </View>
+                <Text style={styles.stepTime}>{formatTime(journey.departureTime)}</Text>
+              </View>
+
+              <View style={styles.step}>
+                <View style={styles.stepIcon}>
+                  <Feather name="flag" size={15} color={colors.tealDark} />
+                </View>
+                <View style={styles.stepBody}>
+                  <Text style={styles.stepLabel}>Arrivée</Text>
+                  <Text style={styles.stepValue}>{journey.arrivalAddress}</Text>
+                </View>
+                <Text style={styles.stepTime}>{formatTime(journey.arrivalTime)}</Text>
+              </View>
+            </View>
+
+            <Text style={styles.sectionTitle}>Votre accompagnement</Text>
+
+            {match ? (
+              <View style={styles.card} testID="journey-detail-match">
+                <View style={styles.personRow}>
+                  <View style={styles.avatar}>
+                    <Text style={styles.avatarText}>
+                      {(match.user?.firstname?.[0] ?? "?").toUpperCase()}
+                    </Text>
+                  </View>
+                  <View style={styles.personBody}>
+                    <Text style={styles.personName}>
+                      {match.user?.firstname} {match.user?.lastname}
+                    </Text>
+                    <View style={styles.confirmedBadge}>
+                      <Feather name="check" size={11} color={colors.successText} />
+                      <Text style={styles.confirmedText}>Trajet confirmé</Text>
+                    </View>
+                  </View>
+                </View>
+
+                {match.user?.phoneNumber && (
+                  <View style={styles.contactRow}>
+                    <Feather name="phone" size={14} color={colors.tealDark} />
+                    <Text style={styles.contactText}>{match.user.phoneNumber}</Text>
+                  </View>
+                )}
+
+                <View style={styles.otherTrip}>
+                  <Text style={styles.otherTripTitle}>Son trajet</Text>
+                  <View style={styles.otherTripRow}>
+                    <Feather name="map-pin" size={13} color={colors.textLight} />
+                    <Text style={styles.otherTripText} numberOfLines={1}>
+                      {match.journey?.departureAddress}
+                    </Text>
+                    <Text style={styles.otherTripTime}>
+                      {formatTime(match.journey?.departureTime)}
+                    </Text>
+                  </View>
+                  <View style={styles.otherTripRow}>
+                    <Feather name="flag" size={13} color={colors.textLight} />
+                    <Text style={styles.otherTripText} numberOfLines={1}>
+                      {match.journey?.arrivalAddress}
+                    </Text>
+                    <Text style={styles.otherTripTime}>
+                      {formatTime(match.journey?.arrivalTime)}
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            ) : (
+              <View style={styles.emptyCard} testID="journey-detail-no-match">
+                <Feather name="clock" size={20} color={colors.textLight} />
+                <Text style={styles.emptyText}>
+                  Ce trajet n&apos;a pas encore d&apos;accompagnement confirmé.
+                </Text>
+              </View>
+            )}
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: 24,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+    ...shadow.card,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: fonts.displayBlack,
+    color: colors.navy,
+    letterSpacing: -0.5,
+  },
+  centered: {
+    paddingVertical: 48,
+    alignItems: "center",
+  },
+  errorContainer: {
+    backgroundColor: colors.dangerBg,
+    padding: 16,
+    borderRadius: radius.md,
+    borderWidth: 1.5,
+    borderColor: colors.dangerBorder,
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontFamily: fonts.bodyMedium,
+  },
+  retryButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+  },
+  retryText: {
+    color: colors.navy,
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    padding: 18,
+    marginBottom: 24,
+    ...shadow.card,
+  },
+  date: {
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+    color: colors.tealDark,
+    marginBottom: 16,
+  },
+  step: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 14,
+  },
+  stepIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.full,
+    backgroundColor: colors.tealLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stepBody: {
+    flex: 1,
+  },
+  stepLabel: {
+    fontSize: 12,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textLight,
+    marginBottom: 2,
+  },
+  stepValue: {
+    fontSize: 15,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.navy,
+  },
+  stepTime: {
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+    color: colors.navy,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontFamily: fonts.displayBold,
+    color: colors.navy,
+    marginBottom: 12,
+    marginLeft: 4,
+  },
+  personRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  avatar: {
+    width: 52,
+    height: 52,
+    borderRadius: radius.full,
+    backgroundColor: colors.tealLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarText: {
+    fontSize: 20,
+    fontFamily: fonts.displayBlack,
+    color: colors.tealDark,
+  },
+  personBody: {
+    flex: 1,
+    gap: 6,
+  },
+  personName: {
+    fontSize: 17,
+    fontFamily: fonts.displayBold,
+    color: colors.navy,
+  },
+  confirmedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    gap: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: radius.full,
+    backgroundColor: colors.successBg,
+  },
+  confirmedText: {
+    fontSize: 11,
+    fontFamily: fonts.bodyBold,
+    color: colors.successText,
+  },
+  contactRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginTop: 16,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    borderTopColor: colors.beige,
+  },
+  contactText: {
+    fontSize: 15,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.navy,
+  },
+  otherTrip: {
+    marginTop: 16,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    borderTopColor: colors.beige,
+  },
+  otherTripTitle: {
+    fontSize: 12,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textLight,
+    marginBottom: 10,
+  },
+  otherTripRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 6,
+  },
+  otherTripText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.navy,
+  },
+  otherTripTime: {
+    fontSize: 13,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textMedium,
+  },
+  emptyCard: {
+    alignItems: "center",
+    gap: 10,
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    paddingVertical: 28,
+    paddingHorizontal: 24,
+    ...shadow.card,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+});

--- a/screens/JourneysScreen.js
+++ b/screens/JourneysScreen.js
@@ -1,0 +1,297 @@
+import { Feather } from "@expo/vector-icons";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { StatusBar } from "expo-status-bar";
+import React, { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import { colors, fonts, radius, shadow } from "../theme/tokens";
+import { formatShortDate, formatTime } from "../utils/format";
+import { getUpcomingConfirmedJourneys } from "../utils/journeys";
+import { getSession } from "../utils/session";
+
+export default function JourneysScreen() {
+  const navigation = useNavigation();
+
+  const [journeys, setJourneys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const session = await getSession();
+    if (!session) {
+      setError("Votre session a expiré. Reconnectez-vous.");
+      setLoading(false);
+      return;
+    }
+
+    const result = await getUpcomingConfirmedJourneys({ token: session.token });
+    if (result.success) {
+      setJourneys(result.journeys);
+    } else {
+      setError(result.message);
+    }
+    setLoading(false);
+  }, []);
+
+  // Reload on focus so a journey confirmed elsewhere shows up on the way back.
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load]),
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <Feather name="arrow-left" size={22} color={colors.navy} />
+          </TouchableOpacity>
+          <Text style={styles.title}>Mes prochains trajets</Text>
+          <Text style={styles.subtitle}>Vos accompagnements confirmés</Text>
+        </View>
+
+        {loading && (
+          <View style={styles.centered} testID="journeys-loading">
+            <ActivityIndicator color={colors.teal} accessibilityLabel="Chargement…" />
+          </View>
+        )}
+
+        {!loading && error && (
+          <View
+            style={styles.errorContainer}
+            testID="journeys-error"
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
+          >
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity
+              style={styles.retryButton}
+              onPress={load}
+              accessibilityRole="button"
+              accessibilityLabel="Réessayer"
+            >
+              <Text style={styles.retryText}>Réessayer</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {!loading && !error && journeys.length === 0 && (
+          <View style={styles.emptyCard} testID="journeys-empty">
+            <Feather name="calendar" size={22} color={colors.textLight} />
+            <Text style={styles.emptyTitle}>Aucun trajet confirmé</Text>
+            <Text style={styles.emptyText}>
+              Vos trajets apparaîtront ici une fois qu&apos;un accompagnement aura été confirmé.
+            </Text>
+          </View>
+        )}
+
+        {!loading && !error && journeys.map((journey) => (
+          <TouchableOpacity
+            key={journey.id}
+            style={styles.journeyCard}
+            onPress={() => navigation.navigate("JourneyDetail", { journeyId: journey.id })}
+            accessibilityRole="button"
+            accessibilityLabel={`Trajet du ${formatShortDate(journey.departureTime)}, ${journey.departureAddress} vers ${journey.arrivalAddress}`}
+            testID={`journey-card-${journey.id}`}
+          >
+            <View style={styles.cardTop}>
+              <Text style={styles.cardDate}>{formatShortDate(journey.departureTime)}</Text>
+              <View style={styles.confirmedBadge}>
+                <Feather name="check" size={11} color={colors.successText} />
+                <Text style={styles.confirmedText}>Confirmé</Text>
+              </View>
+            </View>
+
+            <View style={styles.leg}>
+              <Feather name="map-pin" size={14} color={colors.tealDark} />
+              <Text style={styles.legText} numberOfLines={1}>{journey.departureAddress}</Text>
+              <Text style={styles.legTime}>{formatTime(journey.departureTime)}</Text>
+            </View>
+            <View style={styles.leg}>
+              <Feather name="flag" size={14} color={colors.textLight} />
+              <Text style={styles.legText} numberOfLines={1}>{journey.arrivalAddress}</Text>
+              <Text style={styles.legTime}>{formatTime(journey.arrivalTime)}</Text>
+            </View>
+
+            {journey.match?.user && (
+              <View style={styles.withUser}>
+                <Feather name="user" size={13} color={colors.textMedium} />
+                <Text style={styles.withUserText}>
+                  Avec {journey.match.user.firstname} {journey.match.user.lastname}
+                </Text>
+              </View>
+            )}
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: 24,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+    ...shadow.card,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: fonts.displayBlack,
+    color: colors.navy,
+    letterSpacing: -0.5,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 15,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+  },
+  centered: {
+    paddingVertical: 48,
+    alignItems: "center",
+  },
+  errorContainer: {
+    backgroundColor: colors.dangerBg,
+    padding: 16,
+    borderRadius: radius.md,
+    borderWidth: 1.5,
+    borderColor: colors.dangerBorder,
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontFamily: fonts.bodyMedium,
+  },
+  retryButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+  },
+  retryText: {
+    color: colors.navy,
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+  },
+  emptyCard: {
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    paddingVertical: 36,
+    paddingHorizontal: 24,
+    ...shadow.card,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontFamily: fonts.displayBold,
+    color: colors.navy,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  journeyCard: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    padding: 18,
+    marginBottom: 14,
+    ...shadow.card,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 14,
+  },
+  cardDate: {
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+    color: colors.navy,
+  },
+  confirmedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: radius.full,
+    backgroundColor: colors.successBg,
+  },
+  confirmedText: {
+    fontSize: 11,
+    fontFamily: fonts.bodyBold,
+    color: colors.successText,
+  },
+  leg: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 8,
+  },
+  legText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.navy,
+  },
+  legTime: {
+    fontSize: 13,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textMedium,
+  },
+  withUser: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 8,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.beige,
+  },
+  withUserText: {
+    fontSize: 13,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textMedium,
+  },
+});

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -20,6 +20,7 @@ import BrandInput from "../components/BrandInput";
 import PasswordInput from "../components/PasswordInput";
 import { colors, fonts, radius, shadow } from "../theme/tokens";
 import { apiFetch } from "../utils/api-fetch";
+import { saveSession } from "../utils/session";
 
 export default function LoginScreen() {
   const navigation = useNavigation();
@@ -68,6 +69,7 @@ export default function LoginScreen() {
 
       if (response && response.ok) {
         const payload = await response.json();
+        await saveSession({ token: payload?.data?.token, userId: payload?.data?.userId });
         navigation.reset({
           index: 0,
           routes: [{ name: "Home", params: { userId: payload?.data?.userId } }],

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -1,0 +1,355 @@
+import { Feather } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { StatusBar } from "expo-status-bar";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import { USER_GENRE, USER_ROLES } from "../constants";
+import { colors, fonts, radius, shadow } from "../theme/tokens";
+import { PLACEHOLDER } from "../utils/format";
+import { clearSession, getSession } from "../utils/session";
+import { getUserProfile } from "../utils/users";
+
+/**
+ * Builds the two-letter avatar initials from a profile.
+ * @param {object} profile
+ * @returns {string}
+ */
+function getInitials(profile) {
+  const first = profile?.firstname?.[0] ?? "";
+  const last = profile?.lastname?.[0] ?? "";
+  return `${first}${last}`.toUpperCase() || "?";
+}
+
+export default function ProfileScreen() {
+  const navigation = useNavigation();
+
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const session = await getSession();
+    if (!session) {
+      setError("Votre session a expiré. Reconnectez-vous.");
+      setLoading(false);
+      return;
+    }
+
+    const result = await getUserProfile({ token: session.token });
+    if (result.success) {
+      setProfile(result.profile);
+    } else {
+      setError(result.message);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleLogout = async () => {
+    await clearSession();
+    navigation.reset({ index: 0, routes: [{ name: "Login" }] });
+  };
+
+  const rows = [
+    { label: "Civilité", value: USER_GENRE[profile?.genre] ?? PLACEHOLDER },
+    { label: "Prénom", value: profile?.firstname ?? PLACEHOLDER },
+    { label: "Nom", value: profile?.lastname ?? PLACEHOLDER },
+    { label: "Email", value: profile?.email ?? PLACEHOLDER },
+    { label: "Date de naissance", value: profile?.birthday ?? PLACEHOLDER },
+    { label: "Vous êtes", value: USER_ROLES[profile?.role] ?? PLACEHOLDER },
+  ];
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <Feather name="arrow-left" size={22} color={colors.navy} />
+          </TouchableOpacity>
+          <Text style={styles.title}>Mon profil</Text>
+        </View>
+
+        {loading && (
+          <View style={styles.centered} testID="profile-loading">
+            <ActivityIndicator color={colors.teal} accessibilityLabel="Chargement…" />
+          </View>
+        )}
+
+        {!loading && error && (
+          <View
+            style={styles.errorContainer}
+            testID="profile-error"
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
+          >
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity
+              style={styles.retryButton}
+              onPress={load}
+              accessibilityRole="button"
+              accessibilityLabel="Réessayer"
+            >
+              <Text style={styles.retryText}>Réessayer</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {!loading && !error && profile && (
+          <>
+            <View style={styles.identityCard}>
+              <View style={styles.avatar}>
+                <Text style={styles.avatarText}>{getInitials(profile)}</Text>
+              </View>
+              <Text style={styles.name}>
+                {profile.firstname} {profile.lastname}
+              </Text>
+              <Text style={styles.email}>{profile.email}</Text>
+              <View style={styles.rolePill}>
+                <Feather name="user-check" size={13} color={colors.tealDark} />
+                <Text style={styles.rolePillText}>
+                  {USER_ROLES[profile.role] ?? "Rôle non défini"}
+                </Text>
+              </View>
+            </View>
+
+            <Text style={styles.sectionTitle}>Informations</Text>
+            <View style={styles.card}>
+              {rows.map((row, index) => (
+                <View
+                  key={row.label}
+                  style={[styles.row, index > 0 && styles.rowDivider]}
+                >
+                  <Text style={styles.rowLabel}>{row.label}</Text>
+                  <Text style={styles.rowValue}>{row.value}</Text>
+                </View>
+              ))}
+            </View>
+
+            {profile.disabilities?.length > 0 && (
+              <>
+                <Text style={styles.sectionTitle}>Besoins d&apos;accompagnement</Text>
+                <View style={styles.tagsCard}>
+                  {profile.disabilities.map((disability) => (
+                    <View key={disability} style={styles.tag}>
+                      <Text style={styles.tagText}>{disability}</Text>
+                    </View>
+                  ))}
+                </View>
+              </>
+            )}
+
+            <TouchableOpacity
+              style={styles.logoutButton}
+              onPress={handleLogout}
+              accessibilityRole="button"
+              accessibilityLabel="Se déconnecter"
+            >
+              <Feather name="log-out" size={16} color={colors.danger} />
+              <Text style={styles.logoutText}>Se déconnecter</Text>
+            </TouchableOpacity>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: 24,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+    ...shadow.card,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: fonts.displayBlack,
+    color: colors.navy,
+    letterSpacing: -0.5,
+  },
+  centered: {
+    paddingVertical: 48,
+    alignItems: "center",
+  },
+  errorContainer: {
+    backgroundColor: colors.dangerBg,
+    padding: 16,
+    borderRadius: radius.md,
+    borderWidth: 1.5,
+    borderColor: colors.dangerBorder,
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontFamily: fonts.bodyMedium,
+  },
+  retryButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+  },
+  retryText: {
+    color: colors.navy,
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+  },
+  identityCard: {
+    alignItems: "center",
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    paddingVertical: 28,
+    paddingHorizontal: 20,
+    marginBottom: 28,
+    ...shadow.card,
+  },
+  avatar: {
+    width: 76,
+    height: 76,
+    borderRadius: radius.full,
+    backgroundColor: colors.tealLight,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 14,
+  },
+  avatarText: {
+    fontSize: 26,
+    fontFamily: fonts.displayBlack,
+    color: colors.tealDark,
+  },
+  name: {
+    fontSize: 20,
+    fontFamily: fonts.displayBold,
+    color: colors.navy,
+    marginBottom: 4,
+  },
+  email: {
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+    marginBottom: 14,
+  },
+  rolePill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 7,
+    paddingHorizontal: 14,
+    borderRadius: radius.full,
+    backgroundColor: colors.tealLight,
+  },
+  rolePillText: {
+    fontSize: 13,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.tealDark,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontFamily: fonts.displayBold,
+    color: colors.navy,
+    marginBottom: 12,
+    marginLeft: 4,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    paddingHorizontal: 18,
+    marginBottom: 28,
+    ...shadow.card,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16,
+    paddingVertical: 14,
+  },
+  rowDivider: {
+    borderTopWidth: 1,
+    borderTopColor: colors.beige,
+  },
+  rowLabel: {
+    fontSize: 14,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+  },
+  rowValue: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.navy,
+    textAlign: "right",
+  },
+  tagsCard: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 28,
+  },
+  tag: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: radius.full,
+    backgroundColor: colors.beige,
+  },
+  tagText: {
+    fontSize: 13,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.navy,
+  },
+  logoutButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 16,
+    borderRadius: radius.full,
+    borderWidth: 1.5,
+    borderColor: colors.dangerBorder,
+    backgroundColor: colors.surface,
+  },
+  logoutText: {
+    color: colors.danger,
+    fontSize: 15,
+    fontFamily: fonts.bodyBold,
+  },
+});

--- a/screens/RecordJourneyScreen.js
+++ b/screens/RecordJourneyScreen.js
@@ -1,0 +1,324 @@
+import { Feather } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { StatusBar } from "expo-status-bar";
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import AddressAutocomplete from "../components/AddressAutocomplete";
+import { colors, fonts, radius, shadow } from "../theme/tokens";
+import { recordJourney } from "../utils/journeys";
+import { geocodeAddress, getCurrentPosition, reverseGeocode } from "../utils/location";
+import { getSession } from "../utils/session";
+
+// Estimated arrival used until an explicit time picker is added.
+const DEFAULT_TRIP_MINUTES = 30;
+
+export default function RecordJourneyScreen() {
+  const navigation = useNavigation();
+
+  const [departureAddress, setDepartureAddress] = useState("");
+  const [departureCoords, setDepartureCoords] = useState(null);
+  const [arrivalAddress, setArrivalAddress] = useState("");
+  const [arrivalCoords, setArrivalCoords] = useState(null);
+  const [locating, setLocating] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Typing invalidates the resolved coordinates: they are re-resolved from the
+  // address on submit (or set directly when a suggestion is picked).
+  const onDepartureChange = (text) => {
+    setDepartureAddress(text);
+    setDepartureCoords(null);
+  };
+
+  const onDepartureSelect = (suggestion) => {
+    setDepartureAddress(suggestion.label);
+    setDepartureCoords({ latitude: suggestion.latitude, longitude: suggestion.longitude });
+  };
+
+  const onArrivalChange = (text) => {
+    setArrivalAddress(text);
+    setArrivalCoords(null);
+  };
+
+  const onArrivalSelect = (suggestion) => {
+    setArrivalAddress(suggestion.label);
+    setArrivalCoords({ latitude: suggestion.latitude, longitude: suggestion.longitude });
+  };
+
+  const handleUseMyLocation = async () => {
+    setError(null);
+    setLocating(true);
+    try {
+      const position = await getCurrentPosition();
+      if (!position.granted) {
+        setError("Autorisez la localisation pour utiliser votre position.");
+        return;
+      }
+      const address = await reverseGeocode(position);
+      setDepartureCoords({ latitude: position.latitude, longitude: position.longitude });
+      setDepartureAddress(address);
+    } catch {
+      setError("Impossible de récupérer votre position.");
+    } finally {
+      setLocating(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    if (!departureAddress.trim()) {
+      setError("Indiquez votre point de départ.");
+      return;
+    }
+    if (!arrivalAddress.trim()) {
+      setError("Indiquez votre destination.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const departure = departureCoords ?? (await geocodeAddress(departureAddress));
+      if (!departure) {
+        setError("Adresse de départ introuvable.");
+        return;
+      }
+      const arrival = arrivalCoords ?? (await geocodeAddress(arrivalAddress));
+      if (!arrival) {
+        setError("Adresse d'arrivée introuvable.");
+        return;
+      }
+
+      const session = await getSession();
+      if (!session) {
+        setError("Votre session a expiré. Reconnectez-vous.");
+        return;
+      }
+
+      const now = new Date();
+      const arrivalTime = new Date(now.getTime() + DEFAULT_TRIP_MINUTES * 60000);
+
+      const result = await recordJourney({
+        token: session.token,
+        departureAddress,
+        arrivalAddress,
+        departureLat: departure.latitude,
+        departureLon: departure.longitude,
+        arrivalLat: arrival.latitude,
+        arrivalLon: arrival.longitude,
+        departureTime: now.toISOString(),
+        arrivalTime: arrivalTime.toISOString(),
+      });
+
+      if (result.success) {
+        Alert.alert("Demande envoyée", "Votre trajet a bien été enregistré.", [
+          { text: "OK", onPress: () => navigation.goBack() },
+        ]);
+      } else {
+        setError(result.message);
+      }
+    } catch {
+      setError("Une erreur est survenue. Réessayez.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.keyboardAvoidingView}
+      >
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <View style={styles.header}>
+            <TouchableOpacity
+              style={styles.backButton}
+              onPress={() => navigation.goBack()}
+              accessibilityRole="button"
+              accessibilityLabel="Retour"
+            >
+              <Feather name="arrow-left" size={22} color={colors.navy} />
+            </TouchableOpacity>
+            <Text style={styles.title}>Nouveau trajet</Text>
+            <Text style={styles.subtitle}>Où souhaitez-vous être accompagné ?</Text>
+          </View>
+
+          {error && (
+            <View
+              style={styles.errorContainer}
+              testID="journey-error-container"
+              accessibilityLiveRegion="polite"
+              accessibilityRole="alert"
+            >
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          )}
+
+          <AddressAutocomplete
+            label="Départ"
+            icon="map-pin"
+            placeholder="Adresse de départ"
+            value={departureAddress}
+            onChangeText={onDepartureChange}
+            onSelect={onDepartureSelect}
+            testID="departure-input"
+          />
+
+          <TouchableOpacity
+            style={styles.locationButton}
+            onPress={handleUseMyLocation}
+            disabled={locating}
+            accessibilityRole="button"
+            accessibilityLabel="Utiliser ma position"
+          >
+            {locating ? (
+              <ActivityIndicator color={colors.tealDark} />
+            ) : (
+              <>
+                <Feather name="navigation" size={16} color={colors.tealDark} />
+                <Text style={styles.locationButtonText}>Utiliser ma position</Text>
+              </>
+            )}
+          </TouchableOpacity>
+
+          <AddressAutocomplete
+            label="Destination"
+            icon="flag"
+            placeholder="Adresse d'arrivée"
+            value={arrivalAddress}
+            onChangeText={onArrivalChange}
+            onSelect={onArrivalSelect}
+            testID="arrival-input"
+          />
+
+          <Text style={styles.hint}>Départ planifié : maintenant.</Text>
+
+          <TouchableOpacity
+            style={[styles.submitButton, loading && styles.submitButtonDisabled]}
+            onPress={handleSubmit}
+            disabled={loading}
+            accessibilityRole="button"
+            accessibilityLabel="Demander un accompagnement"
+            accessibilityState={{ disabled: loading }}
+          >
+            {loading ? (
+              <ActivityIndicator color={colors.textOnDark} accessibilityLabel="Chargement…" />
+            ) : (
+              <Text style={styles.submitButtonText}>Demander un accompagnement</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: 28,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    backgroundColor: colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+    ...shadow.card,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: fonts.displayBlack,
+    color: colors.navy,
+    letterSpacing: -0.5,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 15,
+    fontFamily: fonts.body,
+    color: colors.textMedium,
+  },
+  errorContainer: {
+    backgroundColor: colors.dangerBg,
+    padding: 14,
+    borderRadius: radius.md,
+    marginBottom: 16,
+    borderWidth: 1.5,
+    borderColor: colors.dangerBorder,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontFamily: fonts.bodyMedium,
+  },
+  locationButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    alignSelf: "flex-start",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: radius.full,
+    backgroundColor: colors.tealLight,
+    marginTop: -4,
+    marginBottom: 16,
+    minHeight: 44,
+  },
+  locationButtonText: {
+    color: colors.tealDark,
+    fontSize: 14,
+    fontFamily: fonts.bodyBold,
+  },
+  hint: {
+    color: colors.textLight,
+    fontSize: 13,
+    fontFamily: fonts.body,
+    marginLeft: 4,
+    marginBottom: 24,
+  },
+  submitButton: {
+    backgroundColor: colors.teal,
+    paddingVertical: 18,
+    borderRadius: radius.full,
+    alignItems: "center",
+    ...shadow.teal,
+  },
+  submitButtonDisabled: {
+    opacity: 0.6,
+  },
+  submitButtonText: {
+    color: colors.textOnDark,
+    fontSize: 17,
+    fontFamily: fonts.bodyBold,
+    letterSpacing: 0.3,
+  },
+});

--- a/tests/App.test.js
+++ b/tests/App.test.js
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react-native";
 
 import App from "../App.js";
 import { checkHealth } from "../utils/api-fetch";
+import { getSession } from "../utils/session";
 
 // Mock the screens so this suite only verifies the app shell: the API health
 // gate and the navigator's initial route.
@@ -23,22 +24,26 @@ jest.mock("../screens/HomeScreen", () => {
   Screen.displayName = "MockHomeScreen";
   return Screen;
 });
+jest.mock("../screens/RecordJourneyScreen", () => {
+  const { Text } = require("react-native");
+  const Screen = () => <Text>RECORD_JOURNEY_SCREEN</Text>;
+  Screen.displayName = "MockRecordJourneyScreen";
+  return Screen;
+});
 
 jest.mock("../utils/api-fetch", () => ({
   checkHealth: jest.fn(),
 }));
 
+jest.mock("../utils/session", () => ({
+  getSession: jest.fn(),
+}));
+
 describe("App", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("shows the auth flow when the API is healthy", async () => {
     checkHealth.mockResolvedValue(true);
-
-    const { findByText } = render(<App />);
-
-    expect(await findByText("REGISTER_SCREEN")).toBeTruthy();
+    getSession.mockResolvedValue(null);
   });
 
   it("shows an error message when the API is unavailable", async () => {
@@ -47,5 +52,28 @@ describe("App", () => {
     const { findByText } = render(<App />);
 
     expect(await findByText("Service indisponible")).toBeTruthy();
+  });
+
+  it("starts on Register when the API is healthy and no session is stored", async () => {
+    const { findByText } = render(<App />);
+
+    expect(await findByText("REGISTER_SCREEN")).toBeTruthy();
+  });
+
+  it("starts on Home when a session is stored (auto-login)", async () => {
+    getSession.mockResolvedValue({ token: "jwt", userId: 1 });
+
+    const { findByText } = render(<App />);
+
+    expect(await findByText("HOME_SCREEN")).toBeTruthy();
+  });
+
+  it("does not read the session when the API is unavailable", async () => {
+    checkHealth.mockResolvedValue(false);
+
+    const { findByText } = render(<App />);
+    await findByText("Service indisponible");
+
+    expect(getSession).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/AddressAutocomplete.integration.test.js
+++ b/tests/integration/AddressAutocomplete.integration.test.js
@@ -1,0 +1,90 @@
+import { act, fireEvent, render } from "@testing-library/react-native";
+
+import AddressAutocomplete from "../../components/AddressAutocomplete";
+import { searchAddresses } from "../../utils/location";
+
+jest.mock("../../utils/location", () => ({
+  searchAddresses: jest.fn(),
+}));
+
+function setup(props = {}) {
+  const onChangeText = jest.fn();
+  const onSelect = jest.fn();
+  const utils = render(
+    <AddressAutocomplete
+      label="Adresse"
+      icon="map-pin"
+      placeholder="adresse"
+      value=""
+      onChangeText={onChangeText}
+      onSelect={onSelect}
+      testID="addr"
+      {...props}
+    />,
+  );
+  return { onChangeText, onSelect, ...utils };
+}
+
+describe("AddressAutocomplete", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("forwards keystrokes but does not search for short queries", () => {
+    jest.useFakeTimers();
+    const { onChangeText, getByTestId } = setup();
+
+    fireEvent.changeText(getByTestId("addr"), "ab");
+
+    expect(onChangeText).toHaveBeenCalledWith("ab");
+    jest.advanceTimersByTime(500);
+    expect(searchAddresses).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it("shows suggestions after typing and emits the picked one", async () => {
+    searchAddresses.mockResolvedValue([
+      { label: "10 Rue de Paris, Paris", latitude: 48.8, longitude: 2.3 },
+    ]);
+    const { onSelect, getByTestId, findByText } = setup();
+
+    fireEvent.changeText(getByTestId("addr"), "10 rue de paris");
+
+    const suggestion = await findByText("10 Rue de Paris, Paris");
+    fireEvent.press(suggestion);
+
+    expect(onSelect).toHaveBeenCalledWith({
+      label: "10 Rue de Paris, Paris",
+      latitude: 48.8,
+      longitude: 2.3,
+    });
+  });
+
+  it("debounces consecutive keystrokes into a single search", () => {
+    jest.useFakeTimers();
+    searchAddresses.mockResolvedValue([]);
+    const { getByTestId } = setup();
+
+    fireEvent.changeText(getByTestId("addr"), "10 rue");
+    fireEvent.changeText(getByTestId("addr"), "10 rue de paris");
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(searchAddresses).toHaveBeenCalledTimes(1);
+    expect(searchAddresses).toHaveBeenCalledWith("10 rue de paris");
+    jest.useRealTimers();
+  });
+
+  it("clears the pending search timer on unmount", () => {
+    jest.useFakeTimers();
+    const { getByTestId, unmount } = setup();
+
+    fireEvent.changeText(getByTestId("addr"), "10 rue de paris");
+    unmount();
+    jest.advanceTimersByTime(500);
+
+    expect(searchAddresses).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/tests/integration/HomeScreen.integration.test.js
+++ b/tests/integration/HomeScreen.integration.test.js
@@ -1,15 +1,21 @@
-import { fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import HomeScreen from "../../screens/HomeScreen";
 import { checkHealth } from "../../utils/api-fetch";
+import { clearSession } from "../../utils/session";
 
 jest.mock("../../utils/api-fetch", () => ({
     checkHealth: jest.fn(),
 }));
 
+jest.mock("../../utils/session", () => ({
+    clearSession: jest.fn(),
+}));
+
 const mockReset = jest.fn();
+const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => ({
-    useNavigation: () => ({ reset: mockReset }),
+    useNavigation: () => ({ reset: mockReset, navigate: mockNavigate }),
 }));
 
 describe("HomeScreen — Integration Tests", () => {
@@ -34,10 +40,20 @@ describe("HomeScreen — Integration Tests", () => {
         expect(await findByText("API injoignable")).toBeTruthy();
     });
 
-    it("should reset navigation to Login on logout", () => {
+    it("should clear the session and reset navigation to Login on logout", async () => {
         const { getByText } = render(<HomeScreen />);
         fireEvent.press(getByText("Se déconnecter"));
 
-        expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: "Login" }] });
+        await waitFor(() => {
+            expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: "Login" }] });
+        });
+        expect(clearSession).toHaveBeenCalled();
+    });
+
+    it("should navigate to the journey screen from the main action", () => {
+        const { getByText } = render(<HomeScreen />);
+        fireEvent.press(getByText("Demander un accompagnement"));
+
+        expect(mockNavigate).toHaveBeenCalledWith("RecordJourney");
     });
 });

--- a/tests/integration/HomeScreen.integration.test.js
+++ b/tests/integration/HomeScreen.integration.test.js
@@ -1,21 +1,15 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 
 import HomeScreen from "../../screens/HomeScreen";
 import { checkHealth } from "../../utils/api-fetch";
-import { clearSession } from "../../utils/session";
 
 jest.mock("../../utils/api-fetch", () => ({
     checkHealth: jest.fn(),
 }));
 
-jest.mock("../../utils/session", () => ({
-    clearSession: jest.fn(),
-}));
-
-const mockReset = jest.fn();
 const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => ({
-    useNavigation: () => ({ reset: mockReset, navigate: mockNavigate }),
+    useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
 describe("HomeScreen — Integration Tests", () => {
@@ -40,20 +34,24 @@ describe("HomeScreen — Integration Tests", () => {
         expect(await findByText("API injoignable")).toBeTruthy();
     });
 
-    it("should clear the session and reset navigation to Login on logout", async () => {
-        const { getByText } = render(<HomeScreen />);
-        fireEvent.press(getByText("Se déconnecter"));
-
-        await waitFor(() => {
-            expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: "Login" }] });
-        });
-        expect(clearSession).toHaveBeenCalled();
-    });
-
-    it("should navigate to the journey screen from the main action", () => {
+    it("should navigate to the journey form from the main action", () => {
         const { getByText } = render(<HomeScreen />);
         fireEvent.press(getByText("Demander un accompagnement"));
 
         expect(mockNavigate).toHaveBeenCalledWith("RecordJourney");
+    });
+
+    it("should navigate to the journeys list", () => {
+        const { getByText } = render(<HomeScreen />);
+        fireEvent.press(getByText("Mes trajets"));
+
+        expect(mockNavigate).toHaveBeenCalledWith("Journeys");
+    });
+
+    it("should navigate to the profile", () => {
+        const { getByText } = render(<HomeScreen />);
+        fireEvent.press(getByText("Mon profil"));
+
+        expect(mockNavigate).toHaveBeenCalledWith("Profile");
     });
 });

--- a/tests/integration/JourneyDetailScreen.integration.test.js
+++ b/tests/integration/JourneyDetailScreen.integration.test.js
@@ -1,0 +1,102 @@
+import { render } from "@testing-library/react-native";
+
+import JourneyDetailScreen from "../../screens/JourneyDetailScreen";
+import { getJourney, getJourneyMatches } from "../../utils/journeys";
+import { getSession } from "../../utils/session";
+
+jest.mock("../../utils/journeys", () => ({
+    getJourney: jest.fn(),
+    getJourneyMatches: jest.fn(),
+    // Keep the real rule: confirmed means both sides accepted.
+    isConfirmedMatch: (match) => match?.myStatus === "accepted" && match?.otherStatus === "accepted",
+}));
+
+jest.mock("../../utils/session", () => ({
+    getSession: jest.fn(),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+    useNavigation: () => ({ goBack: jest.fn() }),
+    useRoute: () => ({ params: { journeyId: 8 } }),
+}));
+
+const JOURNEY = {
+    id: 8,
+    departureAddress: "12 Rue de Rivoli, Paris",
+    arrivalAddress: "Gare de Lyon, Paris",
+    departureTime: "2026-08-14T15:00:00.000Z",
+    arrivalTime: "2026-08-14T16:00:00.000Z",
+};
+
+const CONFIRMED_MATCH = {
+    foundJourneyId: 1,
+    user: { firstname: "Bob", lastname: "Durand", phoneNumber: "0622222222" },
+    journey: {
+        departureAddress: "10 Rue de Rivoli, Paris",
+        arrivalAddress: "Gare de Lyon, Paris",
+        departureTime: "2026-08-14T15:00:00.000Z",
+        arrivalTime: "2026-08-14T16:00:00.000Z",
+    },
+    myStatus: "accepted",
+    otherStatus: "accepted",
+};
+
+describe("JourneyDetailScreen — Integration Tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getSession.mockResolvedValue({ token: "jwt", userId: 12 });
+        getJourney.mockResolvedValue({ success: true, journey: JOURNEY });
+        getJourneyMatches.mockResolvedValue({ success: true, matches: [CONFIRMED_MATCH] });
+    });
+
+    it("shows the journey details", async () => {
+        const { findByText, getAllByText } = render(<JourneyDetailScreen />);
+
+        expect(await findByText("12 Rue de Rivoli, Paris")).toBeTruthy();
+        // Same arrival for the user and for the matched companion.
+        expect(getAllByText("Gare de Lyon, Paris").length).toBe(2);
+        expect(getJourney).toHaveBeenCalledWith({ token: "jwt", journeyId: 8 });
+    });
+
+    it("shows the other user of a confirmed journey", async () => {
+        const { findByText, getByText } = render(<JourneyDetailScreen />);
+
+        expect(await findByText("Bob Durand")).toBeTruthy();
+        expect(getByText("Trajet confirmé")).toBeTruthy();
+        expect(getByText("0622222222")).toBeTruthy();
+    });
+
+    it("shows the other user's own trip", async () => {
+        const { findByText } = render(<JourneyDetailScreen />);
+
+        expect(await findByText("10 Rue de Rivoli, Paris")).toBeTruthy();
+    });
+
+    it("tells the user when no accompaniment is confirmed yet", async () => {
+        getJourneyMatches.mockResolvedValue({
+            success: true,
+            matches: [{ ...CONFIRMED_MATCH, myStatus: "waiting", otherStatus: "waiting" }],
+        });
+
+        const { findByTestId } = render(<JourneyDetailScreen />);
+
+        expect(await findByTestId("journey-detail-no-match")).toBeTruthy();
+    });
+
+    it("shows an error when the journey cannot be loaded", async () => {
+        getJourney.mockResolvedValue({ success: false, message: "Ce trajet est introuvable." });
+
+        const { findByText } = render(<JourneyDetailScreen />);
+
+        expect(await findByText("Ce trajet est introuvable.")).toBeTruthy();
+    });
+
+    it("asks the user to reconnect when the session is missing", async () => {
+        getSession.mockResolvedValue(null);
+
+        const { findByText } = render(<JourneyDetailScreen />);
+
+        expect(await findByText("Votre session a expiré. Reconnectez-vous.")).toBeTruthy();
+        expect(getJourney).not.toHaveBeenCalled();
+    });
+});

--- a/tests/integration/JourneysScreen.integration.test.js
+++ b/tests/integration/JourneysScreen.integration.test.js
@@ -1,0 +1,93 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import JourneysScreen from "../../screens/JourneysScreen";
+import { getUpcomingConfirmedJourneys } from "../../utils/journeys";
+import { getSession } from "../../utils/session";
+
+jest.mock("../../utils/journeys", () => ({
+    getUpcomingConfirmedJourneys: jest.fn(),
+}));
+
+jest.mock("../../utils/session", () => ({
+    getSession: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+    useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
+    // Run the focus callback once, like a screen coming into view.
+    useFocusEffect: (callback) => {
+        const React = require("react");
+        React.useEffect(callback, [callback]);
+    },
+}));
+
+const JOURNEY = {
+    id: 8,
+    departureAddress: "12 Rue de Rivoli, Paris",
+    arrivalAddress: "Gare de Lyon, Paris",
+    departureTime: "2026-08-14T15:00:00.000Z",
+    arrivalTime: "2026-08-14T16:00:00.000Z",
+    isMatched: true,
+    match: {
+        foundJourneyId: 1,
+        user: { firstname: "Bob", lastname: "Durand" },
+        myStatus: "accepted",
+        otherStatus: "accepted",
+    },
+};
+
+describe("JourneysScreen — Integration Tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getSession.mockResolvedValue({ token: "jwt", userId: 12 });
+        getUpcomingConfirmedJourneys.mockResolvedValue({ success: true, journeys: [JOURNEY] });
+    });
+
+    it("lists the confirmed journeys with the other user", async () => {
+        const { findByText, getByText } = render(<JourneysScreen />);
+
+        expect(await findByText("12 Rue de Rivoli, Paris")).toBeTruthy();
+        expect(getByText("Gare de Lyon, Paris")).toBeTruthy();
+        expect(getByText("Avec Bob Durand")).toBeTruthy();
+        expect(getByText("Confirmé")).toBeTruthy();
+        expect(getUpcomingConfirmedJourneys).toHaveBeenCalledWith({ token: "jwt" });
+    });
+
+    it("opens the journey detail when a journey is tapped", async () => {
+        const { findByTestId } = render(<JourneysScreen />);
+
+        fireEvent.press(await findByTestId("journey-card-8"));
+
+        expect(mockNavigate).toHaveBeenCalledWith("JourneyDetail", { journeyId: 8 });
+    });
+
+    it("shows an empty state when there is no confirmed journey", async () => {
+        getUpcomingConfirmedJourneys.mockResolvedValue({ success: true, journeys: [] });
+
+        const { findByTestId, getByText } = render(<JourneysScreen />);
+
+        expect(await findByTestId("journeys-empty")).toBeTruthy();
+        expect(getByText("Aucun trajet confirmé")).toBeTruthy();
+    });
+
+    it("shows an error when the journeys cannot be loaded", async () => {
+        getUpcomingConfirmedJourneys.mockResolvedValue({
+            success: false,
+            message: "Impossible de récupérer vos trajets. Réessayez.",
+        });
+
+        const { findByText } = render(<JourneysScreen />);
+
+        expect(await findByText("Impossible de récupérer vos trajets. Réessayez.")).toBeTruthy();
+    });
+
+    it("asks the user to reconnect when the session is missing", async () => {
+        getSession.mockResolvedValue(null);
+
+        const { findByText } = render(<JourneysScreen />);
+
+        expect(await findByText("Votre session a expiré. Reconnectez-vous.")).toBeTruthy();
+        expect(getUpcomingConfirmedJourneys).not.toHaveBeenCalled();
+    });
+});

--- a/tests/integration/LoginScreen.integration.test.js
+++ b/tests/integration/LoginScreen.integration.test.js
@@ -2,6 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import LoginScreen from "../../screens/LoginScreen";
 import * as apiFetchModule from "../../utils/api-fetch.js";
+import { saveSession } from "../../utils/session";
 
 jest.mock("@env", () => ({
     KOMPAGNON_API_URL: "http://localhost:3000",
@@ -9,6 +10,10 @@ jest.mock("@env", () => ({
 
 jest.mock("../../utils/api-fetch.js", () => ({
     apiFetch: jest.fn(),
+}));
+
+jest.mock("../../utils/session", () => ({
+    saveSession: jest.fn(),
 }));
 
 const mockNavigate = jest.fn();
@@ -79,6 +84,7 @@ describe("LoginScreen — Integration Tests", () => {
                 routes: [{ name: "Home", params: { userId: 42 } }],
             });
         });
+        expect(saveSession).toHaveBeenCalledWith({ token: "jwt", userId: 42 });
     });
 
     it("should show 'Identifiants incorrects.' on 401", async () => {

--- a/tests/integration/ProfileScreen.integration.test.js
+++ b/tests/integration/ProfileScreen.integration.test.js
@@ -1,0 +1,106 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import ProfileScreen from "../../screens/ProfileScreen";
+import { clearSession, getSession } from "../../utils/session";
+import { getUserProfile } from "../../utils/users";
+
+jest.mock("../../utils/users", () => ({
+    getUserProfile: jest.fn(),
+}));
+
+jest.mock("../../utils/session", () => ({
+    getSession: jest.fn(),
+    clearSession: jest.fn(),
+}));
+
+const mockReset = jest.fn();
+const mockGoBack = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+    useNavigation: () => ({ reset: mockReset, goBack: mockGoBack }),
+}));
+
+const PROFILE = {
+    userId: 12,
+    firstname: "Alice",
+    lastname: "Martin",
+    email: "alice@exemple.com",
+    birthday: "1990-05-12",
+    genre: "F",
+    role: "invalid",
+    disabilities: ["mobility"],
+};
+
+describe("ProfileScreen — Integration Tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getSession.mockResolvedValue({ token: "jwt", userId: 12 });
+        getUserProfile.mockResolvedValue({ success: true, profile: PROFILE });
+    });
+
+    it("shows the profile of the authenticated user", async () => {
+        const { findByText, getByText, getAllByText } = render(<ProfileScreen />);
+
+        expect(await findByText("Alice Martin")).toBeTruthy();
+        // The email shows both in the identity card and in the details rows.
+        expect(getAllByText("alice@exemple.com").length).toBe(2);
+        expect(getByText("1990-05-12")).toBeTruthy();
+        expect(getUserProfile).toHaveBeenCalledWith({ token: "jwt" });
+    });
+
+    it("maps the role and genre to their display labels", async () => {
+        const { findByText, getAllByText } = render(<ProfileScreen />);
+
+        // "Personne handicapé" appears in the role pill and in the details row.
+        expect((await findByText("Mme")).props.children).toBe("Mme");
+        expect(getAllByText("Personne handicapé").length).toBeGreaterThan(0);
+    });
+
+    it("lists the accompaniment needs", async () => {
+        const { findByText } = render(<ProfileScreen />);
+
+        expect(await findByText("mobility")).toBeTruthy();
+    });
+
+    it("shows an error when the profile cannot be loaded", async () => {
+        getUserProfile.mockResolvedValue({ success: false, message: "Impossible de charger votre profil." });
+
+        const { findByText } = render(<ProfileScreen />);
+
+        expect(await findByText("Impossible de charger votre profil.")).toBeTruthy();
+    });
+
+    it("asks the user to reconnect when the session is missing", async () => {
+        getSession.mockResolvedValue(null);
+
+        const { findByText } = render(<ProfileScreen />);
+
+        expect(await findByText("Votre session a expiré. Reconnectez-vous.")).toBeTruthy();
+        expect(getUserProfile).not.toHaveBeenCalled();
+    });
+
+    it("retries loading the profile", async () => {
+        getUserProfile.mockResolvedValueOnce({ success: false, message: "Impossible de charger votre profil." });
+
+        const { findByText } = render(<ProfileScreen />);
+        fireEvent.press(await findByText("Réessayer"));
+
+        expect(await findByText("Alice Martin")).toBeTruthy();
+    });
+
+    it("clears the session and returns to Login on logout", async () => {
+        const { findByText } = render(<ProfileScreen />);
+        fireEvent.press(await findByText("Se déconnecter"));
+
+        await waitFor(() => {
+            expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: "Login" }] });
+        });
+        expect(clearSession).toHaveBeenCalled();
+    });
+
+    it("goes back when tapping the back button", async () => {
+        const { findByLabelText } = render(<ProfileScreen />);
+        fireEvent.press(await findByLabelText("Retour"));
+
+        expect(mockGoBack).toHaveBeenCalled();
+    });
+});

--- a/tests/integration/RecordJourneyScreen.integration.test.js
+++ b/tests/integration/RecordJourneyScreen.integration.test.js
@@ -1,0 +1,229 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { Alert } from "react-native";
+
+import RecordJourneyScreen from "../../screens/RecordJourneyScreen";
+import { recordJourney } from "../../utils/journeys";
+import { geocodeAddress, getCurrentPosition, reverseGeocode } from "../../utils/location";
+import { getSession } from "../../utils/session";
+
+jest.mock("../../utils/location", () => ({
+  geocodeAddress: jest.fn(),
+  getCurrentPosition: jest.fn(),
+  reverseGeocode: jest.fn(),
+}));
+
+jest.mock("../../utils/journeys", () => ({
+  recordJourney: jest.fn(),
+}));
+
+jest.mock("../../utils/session", () => ({
+  getSession: jest.fn(),
+}));
+
+// Decouple the screen from the autocomplete internals: a plain input plus a
+// button that emits a picked suggestion.
+jest.mock("../../components/AddressAutocomplete", () => {
+  const { Text, TextInput, TouchableOpacity } = require("react-native");
+  const MockAutocomplete = ({ value, onChangeText, onSelect, testID }) => (
+    <>
+      <TextInput value={value} onChangeText={onChangeText} testID={testID} />
+      <TouchableOpacity
+        testID={`${testID}-pick`}
+        onPress={() => onSelect({ label: `${testID}-picked`, latitude: 10, longitude: 20 })}
+      >
+        <Text>pick</Text>
+      </TouchableOpacity>
+    </>
+  );
+  MockAutocomplete.displayName = "MockAddressAutocomplete";
+  return MockAutocomplete;
+});
+
+const mockGoBack = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+describe("RecordJourneyScreen — Integration Tests", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fills the departure address from the current position", async () => {
+    getCurrentPosition.mockResolvedValue({ granted: true, latitude: 48.85, longitude: 2.35 });
+    reverseGeocode.mockResolvedValue("10 Rue de Paris, 75001, Paris");
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByText("Utiliser ma position"));
+
+    await waitFor(() => {
+      expect(getByTestId("departure-input").props.value).toBe("10 Rue de Paris, 75001, Paris");
+    });
+  });
+
+  it("shows an error when location permission is denied", async () => {
+    getCurrentPosition.mockResolvedValue({ granted: false });
+
+    const { getByText } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByText("Utiliser ma position"));
+
+    await waitFor(() => {
+      expect(getByText("Autorisez la localisation pour utiliser votre position.")).toBeTruthy();
+    });
+  });
+
+  it("requires a departure before submitting", () => {
+    const { getByText } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    expect(getByText("Indiquez votre point de départ.")).toBeTruthy();
+    expect(recordJourney).not.toHaveBeenCalled();
+  });
+
+  it("records the journey and goes back on success", async () => {
+    jest.spyOn(Alert, "alert");
+    getCurrentPosition.mockResolvedValue({ granted: true, latitude: 48.85, longitude: 2.35 });
+    reverseGeocode.mockResolvedValue("Départ");
+    geocodeAddress.mockResolvedValue({ latitude: 1, longitude: 2 });
+    getSession.mockResolvedValue({ token: "jwt", userId: 1 });
+    recordJourney.mockResolvedValue({ success: true, journeyId: 9 });
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByText("Utiliser ma position"));
+    await waitFor(() => expect(getByTestId("departure-input").props.value).toBe("Départ"));
+
+    fireEvent.changeText(getByTestId("arrival-input"), "Gare de Lyon");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(recordJourney).toHaveBeenCalled();
+    });
+    const payload = recordJourney.mock.calls[0][0];
+    expect(payload.token).toBe("jwt");
+    expect(payload.departureLat).toBe(48.85);
+    expect(payload.arrivalLat).toBe(1);
+    expect(payload.arrivalAddress).toBe("Gare de Lyon");
+
+    expect(Alert.alert).toHaveBeenCalled();
+    const onPress = Alert.alert.mock.calls[0][2][0].onPress;
+    onPress();
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it("shows the API error message when recording fails", async () => {
+    geocodeAddress.mockResolvedValue({ latitude: 1, longitude: 2 });
+    getSession.mockResolvedValue({ token: "jwt" });
+    recordJourney.mockResolvedValue({ success: false, message: "Impossible d'enregistrer le trajet. Réessayez." });
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Départ manuel");
+    fireEvent.changeText(getByTestId("arrival-input"), "Arrivée");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(getByText("Impossible d'enregistrer le trajet. Réessayez.")).toBeTruthy();
+    });
+  });
+
+  it("requires a destination once a departure is set", () => {
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Départ");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    expect(getByText("Indiquez votre destination.")).toBeTruthy();
+    expect(recordJourney).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the departure address cannot be resolved", async () => {
+    geocodeAddress.mockResolvedValueOnce(null);
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Adresse inconnue");
+    fireEvent.changeText(getByTestId("arrival-input"), "Arrivée");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(getByText("Adresse de départ introuvable.")).toBeTruthy();
+    });
+    expect(recordJourney).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the arrival address cannot be resolved", async () => {
+    geocodeAddress
+      .mockResolvedValueOnce({ latitude: 1, longitude: 2 })
+      .mockResolvedValueOnce(null);
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Départ");
+    fireEvent.changeText(getByTestId("arrival-input"), "Adresse inconnue");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(getByText("Adresse d'arrivée introuvable.")).toBeTruthy();
+    });
+  });
+
+  it("asks the user to reconnect when the session is missing", async () => {
+    geocodeAddress.mockResolvedValue({ latitude: 1, longitude: 2 });
+    getSession.mockResolvedValue(null);
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Départ");
+    fireEvent.changeText(getByTestId("arrival-input"), "Arrivée");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(getByText("Votre session a expiré. Reconnectez-vous.")).toBeTruthy();
+    });
+    expect(recordJourney).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when reading the position throws", async () => {
+    getCurrentPosition.mockRejectedValue(new Error("gps off"));
+
+    const { getByText } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByText("Utiliser ma position"));
+
+    await waitFor(() => {
+      expect(getByText("Impossible de récupérer votre position.")).toBeTruthy();
+    });
+  });
+
+  it("goes back when tapping the back button", () => {
+    const { getByLabelText } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByLabelText("Retour"));
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it("shows a generic error when resolving the address throws", async () => {
+    geocodeAddress.mockRejectedValue(new Error("boom"));
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.changeText(getByTestId("departure-input"), "Départ");
+    fireEvent.changeText(getByTestId("arrival-input"), "Arrivée");
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(getByText("Une erreur est survenue. Réessayez.")).toBeTruthy();
+    });
+  });
+
+  it("uses the coordinates from picked suggestions without geocoding", async () => {
+    jest.spyOn(Alert, "alert");
+    getSession.mockResolvedValue({ token: "jwt" });
+    recordJourney.mockResolvedValue({ success: true, journeyId: 1 });
+
+    const { getByText, getByTestId } = render(<RecordJourneyScreen />);
+    fireEvent.press(getByTestId("departure-input-pick"));
+    fireEvent.press(getByTestId("arrival-input-pick"));
+    fireEvent.press(getByText("Demander un accompagnement"));
+
+    await waitFor(() => {
+      expect(recordJourney).toHaveBeenCalled();
+    });
+    const payload = recordJourney.mock.calls[0][0];
+    expect(payload.departureLat).toBe(10);
+    expect(payload.arrivalLat).toBe(10);
+    expect(geocodeAddress).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/journeys.test.js
+++ b/tests/unit/utils/journeys.test.js
@@ -1,5 +1,12 @@
 import { apiFetch } from "../../../utils/api-fetch";
-import { recordJourney } from "../../../utils/journeys";
+import {
+  getJourney,
+  getJourneyMatches,
+  getJourneys,
+  getUpcomingConfirmedJourneys,
+  isConfirmedMatch,
+  recordJourney,
+} from "../../../utils/journeys";
 
 jest.mock("../../../utils/api-fetch", () => ({
   apiFetch: jest.fn(),
@@ -23,7 +30,7 @@ describe("Unit | Utils | recordJourney", () => {
   });
 
   it("posts the journey with a bearer token and returns the id on success", async () => {
-    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: 7 }) });
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: { journeyId: 7 } }) });
 
     const result = await recordJourney(PAYLOAD);
 
@@ -68,5 +75,136 @@ describe("Unit | Utils | recordJourney", () => {
     const result = await recordJourney(PAYLOAD);
 
     expect(result.success).toBe(false);
+  });
+});
+
+describe("Unit | Utils | reading journeys", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists the journeys of the user", async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: 1 }] }) });
+
+    const result = await getJourneys({ token: "jwt" });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/journeys", {
+      headers: { Authorization: "Bearer jwt" },
+    });
+    expect(result).toEqual({ success: true, journeys: [{ id: 1 }] });
+  });
+
+  it("reads one journey", async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: { id: 8 } }) });
+
+    const result = await getJourney({ token: "jwt", journeyId: 8 });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/journeys/8", {
+      headers: { Authorization: "Bearer jwt" },
+    });
+    expect(result).toEqual({ success: true, journey: { id: 8 } });
+  });
+
+  it("reports a missing journey on 404", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    expect(await getJourney({ token: "jwt", journeyId: 8 })).toEqual({
+      success: false,
+      message: "Ce trajet est introuvable.",
+    });
+  });
+
+  it("lists the matches of a journey", async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [{ foundJourneyId: 1 }] }) });
+
+    const result = await getJourneyMatches({ token: "jwt", journeyId: 8 });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/journeys/8/matches", {
+      headers: { Authorization: "Bearer jwt" },
+    });
+    expect(result).toEqual({ success: true, matches: [{ foundJourneyId: 1 }] });
+  });
+});
+
+describe("Unit | Utils | isConfirmedMatch", () => {
+  it("is confirmed only when both sides accepted", () => {
+    expect(isConfirmedMatch({ myStatus: "accepted", otherStatus: "accepted" })).toBe(true);
+    expect(isConfirmedMatch({ myStatus: "accepted", otherStatus: "waiting" })).toBe(false);
+    expect(isConfirmedMatch({ myStatus: "waiting", otherStatus: "accepted" })).toBe(false);
+    expect(isConfirmedMatch(undefined)).toBe(false);
+  });
+});
+
+describe("Unit | Utils | getUpcomingConfirmedJourneys", () => {
+  const NOW = new Date("2026-08-13T12:00:00.000Z");
+
+  const future = (id, hours) => ({
+    id,
+    isMatched: true,
+    departureTime: new Date(NOW.getTime() + hours * 3600000).toISOString(),
+    arrivalTime: new Date(NOW.getTime() + (hours + 1) * 3600000).toISOString(),
+  });
+
+  const accepted = { myStatus: "accepted", otherStatus: "accepted", user: { firstname: "Bob" } };
+  const waiting = { myStatus: "waiting", otherStatus: "waiting" };
+
+  function mockApi({ journeys, matchesByJourneyId }) {
+    apiFetch.mockImplementation(async (endpoint) => {
+      const matchMatches = endpoint.match(/^\/api\/journeys\/(\d+)\/matches$/);
+      if (matchMatches) {
+        return { ok: true, json: async () => ({ data: matchesByJourneyId[matchMatches[1]] ?? [] }) };
+      }
+      return { ok: true, json: async () => ({ data: journeys }) };
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps only journeys whose match is accepted by both sides", async () => {
+    mockApi({
+      journeys: [future(1, 5), future(2, 8)],
+      matchesByJourneyId: { 1: [accepted], 2: [waiting] },
+    });
+
+    const result = await getUpcomingConfirmedJourneys({ token: "jwt", now: NOW });
+
+    expect(result.success).toBe(true);
+    expect(result.journeys.map((journey) => journey.id)).toEqual([1]);
+    expect(result.journeys[0].match).toEqual(accepted);
+  });
+
+  it("drops past journeys and journeys without a match", async () => {
+    const past = { ...future(3, -10), isMatched: true };
+    const unmatched = { ...future(4, 6), isMatched: false };
+    mockApi({
+      journeys: [past, unmatched],
+      matchesByJourneyId: { 3: [accepted], 4: [accepted] },
+    });
+
+    const result = await getUpcomingConfirmedJourneys({ token: "jwt", now: NOW });
+
+    expect(result.journeys).toEqual([]);
+  });
+
+  it("sorts the confirmed journeys by departure time", async () => {
+    mockApi({
+      journeys: [future(1, 9), future(2, 3)],
+      matchesByJourneyId: { 1: [accepted], 2: [accepted] },
+    });
+
+    const result = await getUpcomingConfirmedJourneys({ token: "jwt", now: NOW });
+
+    expect(result.journeys.map((journey) => journey.id)).toEqual([2, 1]);
+  });
+
+  it("propagates a listing failure", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 401 });
+
+    const result = await getUpcomingConfirmedJourneys({ token: "jwt", now: NOW });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Session expirée. Reconnectez-vous.");
   });
 });

--- a/tests/unit/utils/journeys.test.js
+++ b/tests/unit/utils/journeys.test.js
@@ -1,0 +1,72 @@
+import { apiFetch } from "../../../utils/api-fetch";
+import { recordJourney } from "../../../utils/journeys";
+
+jest.mock("../../../utils/api-fetch", () => ({
+  apiFetch: jest.fn(),
+}));
+
+const PAYLOAD = {
+  token: "jwt",
+  departureAddress: "A",
+  arrivalAddress: "B",
+  departureLat: 1,
+  departureLon: 2,
+  arrivalLat: 3,
+  arrivalLon: 4,
+  departureTime: "2024-01-01T10:00:00.000Z",
+  arrivalTime: "2024-01-01T10:30:00.000Z",
+};
+
+describe("Unit | Utils | recordJourney", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("posts the journey with a bearer token and returns the id on success", async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: 7 }) });
+
+    const result = await recordJourney(PAYLOAD);
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/journeys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer jwt" },
+      body: JSON.stringify({
+        departureAddress: "A",
+        arrivalAddress: "B",
+        departureLat: 1,
+        departureLon: 2,
+        arrivalLat: 3,
+        arrivalLon: 4,
+        departureTime: "2024-01-01T10:00:00.000Z",
+        arrivalTime: "2024-01-01T10:30:00.000Z",
+      }),
+    });
+    expect(result).toEqual({ success: true, journeyId: 7 });
+  });
+
+  it("returns a session message on 401", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 401 });
+
+    expect(await recordJourney(PAYLOAD)).toEqual({
+      success: false,
+      message: "Session expirée. Reconnectez-vous.",
+    });
+  });
+
+  it("returns a generic message on other failures", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await recordJourney(PAYLOAD);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Impossible d'enregistrer le trajet. Réessayez.");
+  });
+
+  it("returns a message when the request throws", async () => {
+    apiFetch.mockRejectedValue(new Error("network"));
+
+    const result = await recordJourney(PAYLOAD);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/utils/location.test.js
+++ b/tests/unit/utils/location.test.js
@@ -1,0 +1,96 @@
+jest.mock("expo-location", () => ({
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+  reverseGeocodeAsync: jest.fn(),
+  geocodeAsync: jest.fn(),
+}));
+
+import * as Location from "expo-location";
+
+import { geocodeAddress, getCurrentPosition, reverseGeocode, searchAddresses } from "../../../utils/location";
+
+describe("Unit | Utils | location", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getCurrentPosition", () => {
+    it("returns coordinates when permission is granted", async () => {
+      Location.requestForegroundPermissionsAsync.mockResolvedValue({ status: "granted" });
+      Location.getCurrentPositionAsync.mockResolvedValue({ coords: { latitude: 48.85, longitude: 2.35 } });
+
+      expect(await getCurrentPosition()).toEqual({ granted: true, latitude: 48.85, longitude: 2.35 });
+    });
+
+    it("returns granted:false and does not read the position when permission is denied", async () => {
+      Location.requestForegroundPermissionsAsync.mockResolvedValue({ status: "denied" });
+
+      expect(await getCurrentPosition()).toEqual({ granted: false });
+      expect(Location.getCurrentPositionAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reverseGeocode", () => {
+    it("builds a readable address from the first match", async () => {
+      Location.reverseGeocodeAsync.mockResolvedValue([
+        { streetNumber: "10", street: "Rue de Paris", postalCode: "75001", city: "Paris" },
+      ]);
+
+      expect(await reverseGeocode({ latitude: 1, longitude: 2 })).toBe("10 Rue de Paris, 75001, Paris");
+    });
+
+    it("returns an empty string when nothing is found", async () => {
+      Location.reverseGeocodeAsync.mockResolvedValue([]);
+
+      expect(await reverseGeocode({ latitude: 1, longitude: 2 })).toBe("");
+    });
+  });
+
+  describe("geocodeAddress", () => {
+    it("returns coordinates for an address", async () => {
+      Location.geocodeAsync.mockResolvedValue([{ latitude: 48.85, longitude: 2.35 }]);
+
+      expect(await geocodeAddress("Paris")).toEqual({ latitude: 48.85, longitude: 2.35 });
+    });
+
+    it("returns null when the address is not found", async () => {
+      Location.geocodeAsync.mockResolvedValue([]);
+
+      expect(await geocodeAddress("nowhere")).toBeNull();
+    });
+  });
+
+  describe("searchAddresses", () => {
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    it("returns an empty list for short queries without calling the network", async () => {
+      expect(await searchAddresses("ab")).toEqual([]);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("maps results to a label and coordinates", async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => [{ display_name: "10 Rue de Paris, Paris", lat: "48.8", lon: "2.3" }],
+      });
+
+      expect(await searchAddresses("10 rue de paris")).toEqual([
+        { label: "10 Rue de Paris, Paris", latitude: 48.8, longitude: 2.3 },
+      ]);
+    });
+
+    it("returns an empty list on a non-ok response", async () => {
+      fetch.mockResolvedValue({ ok: false });
+
+      expect(await searchAddresses("paris")).toEqual([]);
+    });
+
+    it("returns an empty list when the request throws", async () => {
+      fetch.mockRejectedValue(new Error("network"));
+
+      expect(await searchAddresses("paris")).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/utils/session.test.js
+++ b/tests/unit/utils/session.test.js
@@ -1,0 +1,71 @@
+jest.mock("expo-secure-store", () => {
+  const store = new Map();
+  return {
+    __store: store,
+    setItemAsync: jest.fn(async (key, value) => { store.set(key, value); }),
+    getItemAsync: jest.fn(async (key) => (store.has(key) ? store.get(key) : null)),
+    deleteItemAsync: jest.fn(async (key) => { store.delete(key); }),
+  };
+});
+
+import * as SecureStore from "expo-secure-store";
+
+import { clearSession, getSession, saveSession } from "../../../utils/session.js";
+
+describe("Unit | Utils | session", () => {
+  beforeEach(() => {
+    SecureStore.__store.clear();
+    jest.clearAllMocks();
+  });
+
+  it("returns null when no session is stored", async () => {
+    expect(await getSession()).toBeNull();
+  });
+
+  it("saves then reads back the token and user id", async () => {
+    await saveSession({ token: "jwt-123", userId: 42 });
+
+    expect(await getSession()).toEqual({ token: "jwt-123", userId: 42 });
+  });
+
+  it("stores the user id as null when it is not provided", async () => {
+    await saveSession({ token: "jwt-123" });
+
+    expect(await getSession()).toEqual({ token: "jwt-123", userId: null });
+    expect(SecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the stored session", async () => {
+    await saveSession({ token: "jwt-123", userId: 42 });
+
+    await clearSession();
+
+    expect(await getSession()).toBeNull();
+  });
+
+  describe("web fallback", () => {
+    it("uses localStorage on web", async () => {
+      const store = {};
+      global.localStorage = {
+        setItem: (key, value) => { store[key] = value; },
+        getItem: (key) => (key in store ? store[key] : null),
+        removeItem: (key) => { delete store[key]; },
+      };
+
+      let session;
+      jest.isolateModules(() => {
+        jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+        session = require("../../../utils/session.js");
+      });
+
+      await session.saveSession({ token: "web-token", userId: 5 });
+      expect(store.auth_token).toBe("web-token");
+      expect(await session.getSession()).toEqual({ token: "web-token", userId: 5 });
+
+      await session.clearSession();
+      expect(await session.getSession()).toBeNull();
+
+      delete global.localStorage;
+    });
+  });
+});

--- a/tests/unit/utils/users.test.js
+++ b/tests/unit/utils/users.test.js
@@ -1,0 +1,49 @@
+import { apiFetch } from "../../../utils/api-fetch";
+import { getUserProfile } from "../../../utils/users";
+
+jest.mock("../../../utils/api-fetch", () => ({
+  apiFetch: jest.fn(),
+}));
+
+const PROFILE = { userId: 12, firstname: "Alice", lastname: "Martin" };
+
+describe("Unit | Utils | getUserProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reads the profile with a bearer token", async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({ data: PROFILE }) });
+
+    const result = await getUserProfile({ token: "jwt" });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/users/profile", {
+      headers: { Authorization: "Bearer jwt" },
+    });
+    expect(result).toEqual({ success: true, profile: PROFILE });
+  });
+
+  it("reports an expired session on 401", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 401 });
+
+    expect(await getUserProfile({ token: "jwt" })).toEqual({
+      success: false,
+      message: "Session expirée. Reconnectez-vous.",
+    });
+  });
+
+  it("reports a generic failure on other errors", async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await getUserProfile({ token: "jwt" });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Impossible de charger votre profil.");
+  });
+
+  it("reports a failure when the request throws", async () => {
+    apiFetch.mockRejectedValue(new Error("network"));
+
+    expect((await getUserProfile({ token: "jwt" })).success).toBe(false);
+  });
+});

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,0 +1,34 @@
+const PLACEHOLDER = "—";
+
+/**
+ * Formats an ISO date-time as a short French date, e.g. "jeu. 14 août 2026".
+ * @param {string} isoString
+ * @returns {string}
+ */
+function formatShortDate(isoString) {
+  const date = new Date(isoString);
+  if (!isoString || isNaN(date.getTime())) {
+    return PLACEHOLDER;
+  }
+  return date.toLocaleDateString("fr-FR", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+/**
+ * Formats an ISO date-time as a French time, e.g. "15:04".
+ * @param {string} isoString
+ * @returns {string}
+ */
+function formatTime(isoString) {
+  const date = new Date(isoString);
+  if (!isoString || isNaN(date.getTime())) {
+    return PLACEHOLDER;
+  }
+  return date.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+export { formatShortDate, formatTime, PLACEHOLDER };

--- a/utils/journeys.js
+++ b/utils/journeys.js
@@ -1,0 +1,63 @@
+import { apiFetch } from "./api-fetch";
+
+/**
+ * Records a journey for the authenticated user. The API stores it as a passenger
+ * or companion journey (depending on the user's role) and uses it for matching.
+ * Coordinates must be resolved beforehand (see utils/location).
+ *
+ * @param {object}  params
+ * @param {string}  params.token            - Bearer token of the authenticated user.
+ * @param {string}  params.departureAddress
+ * @param {string}  params.arrivalAddress
+ * @param {number}  params.departureLat
+ * @param {number}  params.departureLon
+ * @param {number}  params.arrivalLat
+ * @param {number}  params.arrivalLon
+ * @param {string}  params.departureTime    - ISO date-time.
+ * @param {string}  params.arrivalTime      - ISO date-time.
+ * @returns {Promise<{ success: boolean, journeyId?: number, message?: string }>}
+ */
+async function recordJourney({
+  token,
+  departureAddress,
+  arrivalAddress,
+  departureLat,
+  departureLon,
+  arrivalLat,
+  arrivalLon,
+  departureTime,
+  arrivalTime,
+}) {
+  try {
+    const response = await apiFetch("/api/journeys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        departureAddress,
+        arrivalAddress,
+        departureLat,
+        departureLon,
+        arrivalLat,
+        arrivalLon,
+        departureTime,
+        arrivalTime,
+      }),
+    });
+
+    if (response && response.ok) {
+      const data = await response.json();
+      return { success: true, journeyId: data?.data };
+    }
+    if (response && response.status === 401) {
+      return { success: false, message: "Session expirée. Reconnectez-vous." };
+    }
+    return { success: false, message: "Impossible d'enregistrer le trajet. Réessayez." };
+  } catch {
+    return { success: false, message: "Une erreur est survenue. Vérifiez votre connexion." };
+  }
+}
+
+export { recordJourney };

--- a/utils/journeys.js
+++ b/utils/journeys.js
@@ -1,5 +1,17 @@
 import { apiFetch } from "./api-fetch";
 
+const JOURNEYS_URL = "/api/journeys";
+
+const SESSION_EXPIRED = "Session expirée. Reconnectez-vous.";
+const UNREACHABLE = "Une erreur est survenue. Vérifiez votre connexion.";
+
+/** A match is confirmed once both sides have accepted it. */
+const ACCEPTED = "accepted";
+
+function authHeaders(token) {
+  return { Authorization: `Bearer ${token}` };
+}
+
 /**
  * Records a journey for the authenticated user. The API stores it as a passenger
  * or companion journey (depending on the user's role) and uses it for matching.
@@ -29,11 +41,11 @@ async function recordJourney({
   arrivalTime,
 }) {
   try {
-    const response = await apiFetch("/api/journeys", {
+    const response = await apiFetch(JOURNEYS_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+        ...authHeaders(token),
       },
       body: JSON.stringify({
         departureAddress,
@@ -49,15 +61,140 @@ async function recordJourney({
 
     if (response && response.ok) {
       const data = await response.json();
-      return { success: true, journeyId: data?.data };
+      return { success: true, journeyId: data?.data?.journeyId };
     }
     if (response && response.status === 401) {
-      return { success: false, message: "Session expirée. Reconnectez-vous." };
+      return { success: false, message: SESSION_EXPIRED };
     }
     return { success: false, message: "Impossible d'enregistrer le trajet. Réessayez." };
   } catch {
-    return { success: false, message: "Une erreur est survenue. Vérifiez votre connexion." };
+    return { success: false, message: UNREACHABLE };
   }
 }
 
-export { recordJourney };
+/**
+ * Lists the journeys of the authenticated user.
+ * @param {{ token: string }} params
+ * @returns {Promise<{ success: boolean, journeys?: object[], message?: string }>}
+ */
+async function getJourneys({ token }) {
+  try {
+    const response = await apiFetch(JOURNEYS_URL, { headers: authHeaders(token) });
+
+    if (response && response.ok) {
+      const data = await response.json();
+      return { success: true, journeys: data?.data ?? [] };
+    }
+    if (response && response.status === 401) {
+      return { success: false, message: SESSION_EXPIRED };
+    }
+    return { success: false, message: "Impossible de récupérer vos trajets. Réessayez." };
+  } catch {
+    return { success: false, message: UNREACHABLE };
+  }
+}
+
+/**
+ * Reads one journey of the authenticated user.
+ * @param {{ token: string, journeyId: number }} params
+ * @returns {Promise<{ success: boolean, journey?: object, message?: string }>}
+ */
+async function getJourney({ token, journeyId }) {
+  try {
+    const response = await apiFetch(`${JOURNEYS_URL}/${journeyId}`, { headers: authHeaders(token) });
+
+    if (response && response.ok) {
+      const data = await response.json();
+      return { success: true, journey: data?.data };
+    }
+    if (response && response.status === 401) {
+      return { success: false, message: SESSION_EXPIRED };
+    }
+    if (response && response.status === 404) {
+      return { success: false, message: "Ce trajet est introuvable." };
+    }
+    return { success: false, message: "Impossible de récupérer le trajet. Réessayez." };
+  } catch {
+    return { success: false, message: UNREACHABLE };
+  }
+}
+
+/**
+ * Lists the matches of a journey. Each match carries the other user and their
+ * side of the trip, plus both acceptance statuses.
+ * @param {{ token: string, journeyId: number }} params
+ * @returns {Promise<{ success: boolean, matches?: object[], message?: string }>}
+ */
+async function getJourneyMatches({ token, journeyId }) {
+  try {
+    const response = await apiFetch(`${JOURNEYS_URL}/${journeyId}/matches`, {
+      headers: authHeaders(token),
+    });
+
+    if (response && response.ok) {
+      const data = await response.json();
+      return { success: true, matches: data?.data ?? [] };
+    }
+    if (response && response.status === 401) {
+      return { success: false, message: SESSION_EXPIRED };
+    }
+    return { success: false, message: "Impossible de récupérer les correspondances." };
+  } catch {
+    return { success: false, message: UNREACHABLE };
+  }
+}
+
+/**
+ * True when both sides accepted the match.
+ * @param {object} match
+ * @returns {boolean}
+ */
+function isConfirmedMatch(match) {
+  return match?.myStatus === ACCEPTED && match?.otherStatus === ACCEPTED;
+}
+
+/**
+ * Upcoming journeys that are confirmed, i.e. matched with a companion (or a
+ * passenger) who accepted, sorted by departure time.
+ *
+ * The API has no "confirmed" filter and the list only carries an `isMatched`
+ * flag, which stays true while a match is still pending. Confirmation therefore
+ * has to be read from each journey's matches, fetched in parallel.
+ *
+ * @param {{ token: string, now?: Date }} params
+ * @returns {Promise<{ success: boolean, journeys?: object[], message?: string }>}
+ */
+async function getUpcomingConfirmedJourneys({ token, now = new Date() }) {
+  const result = await getJourneys({ token });
+  if (!result.success) {
+    return result;
+  }
+
+  const upcoming = result.journeys.filter((journey) => {
+    const arrival = new Date(journey.arrivalTime);
+    return !isNaN(arrival.getTime()) && arrival >= now && journey.isMatched;
+  });
+
+  const withMatches = await Promise.all(
+    upcoming.map(async (journey) => {
+      const matches = await getJourneyMatches({ token, journeyId: journey.id });
+      const confirmed = (matches.matches ?? []).find(isConfirmedMatch);
+      return confirmed ? { ...journey, match: confirmed } : null;
+    }),
+  );
+
+  const journeys = withMatches
+    .filter(Boolean)
+    .sort((a, b) => new Date(a.departureTime) - new Date(b.departureTime));
+
+  return { success: true, journeys };
+}
+
+export {
+  getJourney,
+  getJourneyMatches,
+  getJourneys,
+  getUpcomingConfirmedJourneys,
+  isConfirmedMatch,
+  recordJourney,
+};

--- a/utils/location.js
+++ b/utils/location.js
@@ -1,0 +1,75 @@
+import * as Location from "expo-location";
+
+/**
+ * Requests foreground location permission and reads the current coordinates.
+ * @returns {Promise<{ granted: boolean, latitude?: number, longitude?: number }>}
+ */
+async function getCurrentPosition() {
+  const { status } = await Location.requestForegroundPermissionsAsync();
+  if (status !== "granted") {
+    return { granted: false };
+  }
+  const { coords } = await Location.getCurrentPositionAsync({});
+  return { granted: true, latitude: coords.latitude, longitude: coords.longitude };
+}
+
+/**
+ * Turns coordinates into a readable address, or "" when none is found.
+ * @param {{ latitude: number, longitude: number }} coords
+ * @returns {Promise<string>}
+ */
+async function reverseGeocode({ latitude, longitude }) {
+  const [place] = await Location.reverseGeocodeAsync({ latitude, longitude });
+  if (!place) {
+    return "";
+  }
+  const street = [place.streetNumber, place.street].filter(Boolean).join(" ");
+  return [street, place.postalCode, place.city].filter(Boolean).join(", ");
+}
+
+/**
+ * Resolves an address to coordinates, or null when none is found.
+ * @param {string} address
+ * @returns {Promise<{ latitude: number, longitude: number }|null>}
+ */
+async function geocodeAddress(address) {
+  const [match] = await Location.geocodeAsync(address);
+  if (!match) {
+    return null;
+  }
+  return { latitude: match.latitude, longitude: match.longitude };
+}
+
+// Free OpenStreetMap geocoder. Fine for development; a production app should use
+// a keyed provider (Google/Mapbox) or a self-hosted Nominatim instance.
+const NOMINATIM_SEARCH_URL = "https://nominatim.openstreetmap.org/search";
+
+/**
+ * Searches addresses matching a query, for autocomplete suggestions.
+ * Returns an empty list for short queries or on any error.
+ * @param {string} query
+ * @returns {Promise<Array<{ label: string, latitude: number, longitude: number }>>}
+ */
+async function searchAddresses(query) {
+  const trimmed = (query || "").trim();
+  if (trimmed.length < 3) {
+    return [];
+  }
+  try {
+    const url = `${NOMINATIM_SEARCH_URL}?format=json&limit=5&accept-language=fr&q=${encodeURIComponent(trimmed)}`;
+    const response = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!response.ok) {
+      return [];
+    }
+    const results = await response.json();
+    return results.map((place) => ({
+      label: place.display_name,
+      latitude: Number(place.lat),
+      longitude: Number(place.lon),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export { geocodeAddress, getCurrentPosition, reverseGeocode, searchAddresses };

--- a/utils/session.js
+++ b/utils/session.js
@@ -1,0 +1,69 @@
+import * as SecureStore from "expo-secure-store";
+import { Platform } from "react-native";
+
+// Same key names as the web auth store.
+const TOKEN_KEY = "auth_token";
+const USER_ID_KEY = "auth_user_id";
+
+// expo-secure-store has no web implementation, so on web we fall back to
+// localStorage. On native we use the device's secure storage.
+const isWeb = Platform.OS === "web";
+
+async function setItem(key, value) {
+  if (isWeb) {
+    globalThis.localStorage?.setItem(key, value);
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+async function getItem(key) {
+  if (isWeb) {
+    return globalThis.localStorage?.getItem(key) ?? null;
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function removeItem(key) {
+  if (isWeb) {
+    globalThis.localStorage?.removeItem(key);
+    return;
+  }
+  await SecureStore.deleteItemAsync(key);
+}
+
+/**
+ * Persists the authenticated session (bearer token + user id).
+ * @param {{ token: string, userId?: number }} session
+ * @returns {Promise<void>}
+ */
+async function saveSession({ token, userId }) {
+  await setItem(TOKEN_KEY, token);
+  if (userId != null) {
+    await setItem(USER_ID_KEY, String(userId));
+  }
+}
+
+/**
+ * Reads the stored session, or null if the user is not logged in.
+ * @returns {Promise<{ token: string, userId: number|null }|null>}
+ */
+async function getSession() {
+  const token = await getItem(TOKEN_KEY);
+  if (!token) {
+    return null;
+  }
+  const userId = await getItem(USER_ID_KEY);
+  return { token, userId: userId ? Number(userId) : null };
+}
+
+/**
+ * Clears the stored session (logout).
+ * @returns {Promise<void>}
+ */
+async function clearSession() {
+  await removeItem(TOKEN_KEY);
+  await removeItem(USER_ID_KEY);
+}
+
+export { clearSession, getSession, saveSession };

--- a/utils/users.js
+++ b/utils/users.js
@@ -1,0 +1,27 @@
+import { apiFetch } from "./api-fetch";
+
+/**
+ * Reads the profile of the authenticated user.
+ * @param {{ token: string }} params
+ * @returns {Promise<{ success: boolean, profile?: object, message?: string }>}
+ */
+async function getUserProfile({ token }) {
+  try {
+    const response = await apiFetch("/api/users/profile", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (response && response.ok) {
+      const data = await response.json();
+      return { success: true, profile: data?.data };
+    }
+    if (response && response.status === 401) {
+      return { success: false, message: "Session expirée. Reconnectez-vous." };
+    }
+    return { success: false, message: "Impossible de charger votre profil." };
+  } catch {
+    return { success: false, message: "Une erreur est survenue. Vérifiez votre connexion." };
+  }
+}
+
+export { getUserProfile };


### PR DESCRIPTION
Stacked on #104 — review that one first, this PR targets its branch so the diff stays focused.

Closes #99. Contributes to #107 and #15.

## What

Adds the three authenticated sections the app was missing, all reachable from Home.

### Record a journey (the mobile-specific part)
The departure can be filled from the device GPS (reverse geocoded), the destination picked from debounced address suggestions, and both are resolved to coordinates before `POST /api/journeys`.

### Profile — #99, and #15 partially
Reads `GET /api/users/profile` and shows identity, civility, role and accompaniment needs. Logout moved here from Home.

### Journeys — #107
Lists the upcoming journeys and opens their details with the other user, their trip and their phone number once both sides accepted.

**On "only confirmed journeys":** the API exposes no confirmed filter, and the `isMatched` flag in `GET /api/journeys` stays true while a match is still pending. Confirmation is therefore read from each journey's matches (`myStatus` and `otherStatus` both `accepted`), fetched in parallel. Verified against a seeded API: a journey matched but still `waiting` is correctly left out.

### Session
The bearer token is persisted (expo-secure-store, localStorage on web), so a logged-in user goes straight to Home.

## Also fixed
`recordJourney` read the new journey id one level too high in the API response (`data` instead of `data.journeyId`).

## Tests
144 passing, 97% coverage, lint clean. The three screens were also checked against a locally running API with seeded passenger/companion accounts and matches.

## Not in this PR
- **#15 "change your user profile (photo, password)"** is not implementable yet: the API has no profile update endpoint (the web is read-only too).
- **Accepting or rejecting a match** exists on the web (`PUT /api/journeys/found/:id`) but not here. Since #107 asks for confirmed journeys only, a pending match is never reachable from the app — worth a follow-up issue and a product decision.