### PR TITLE
tech: Restore dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "./"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: bump
+      include: scope
+    labels:
+      - Ready to merge
+      - no-coverage


### PR DESCRIPTION
## Problem

We don't have a solution to update the github actions echo system.

## Solution

REstore the dependabot file, but without npm checking.
